### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.Dictionary.json
+++ b/org.gnome.Dictionary.json
@@ -19,8 +19,6 @@
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
     "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g",
         "env": {
             "V": 1
         }


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.