### PR TITLE
EOL Dictionary

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "Dictionary is end-of-life and will no longer be receiving updates."
+}


### PR DESCRIPTION
https://gitlab.gnome.org/Archive/gnome-dictionary is archived. It's failing to build with newer runtime.